### PR TITLE
objtool: remove tail call from validate_branch to fix host build issue

### DIFF
--- a/tools/objtool/check.c
+++ b/tools/objtool/check.c
@@ -2676,12 +2676,6 @@ static int validate_branch(struct objtool_file *file, struct symbol *func,
 			if (dead_end_function(file, insn->call_dest))
 				return 0;
 
-			if (insn->type == INSN_CALL && insn->call_dest &&
-					insn->call_dest->static_call_tramp) {
-				list_add_tail(&insn->static_call_node,
-					      &file->static_call_list);
-			}
-
 			break;
 
 		case INSN_JUMP_CONDITIONAL:


### PR DESCRIPTION
This fix was introduced in the commit f0bc12b8482684fe4d0e48b367ca4fcb8580e81a

Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>